### PR TITLE
Add a way not to have transaction partionning applying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist/
 
 # Ignore PyCharm / IntelliJ files
 .idea/
+*.iml

--- a/docs/source/table_partitioning.rst
+++ b/docs/source/table_partitioning.rst
@@ -177,6 +177,16 @@ Time-based partitioning
    ])
 
 
+Running management operations in a non atomic way
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Partitions creating and deletion can be done in a non-atomic way.
+This can be useful to reduce lock contention when performing partition operations on a table while it is under heavy load.
+Note that obviously this can lead to partially created/deleted partitions if something goes wrong during the operations.
+By default all operations are done in an atomic way.
+
+You can disable atomic operations by setting the `atomic` parameter to `False` in the `PostgresPartitioningConfig` constructor.
+
 Changing a time partitioning strategy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/table_partitioning.rst
+++ b/docs/source/table_partitioning.rst
@@ -180,7 +180,7 @@ Time-based partitioning
 Running management operations in a non atomic way
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Partitions creating and deletion can be done in a non-atomic way.
+Partitions creation and deletion can be done in a non-atomic way.
 This can be useful to reduce lock contention when performing partition operations on a table while it is under heavy load.
 Note that obviously this can lead to partially created/deleted partitions if something goes wrong during the operations.
 By default all operations are done in an atomic way.

--- a/psqlextra/partitioning/config.py
+++ b/psqlextra/partitioning/config.py
@@ -13,9 +13,11 @@ class PostgresPartitioningConfig:
         self,
         model: Type[PostgresPartitionedModel],
         strategy: PostgresPartitioningStrategy,
+        atomic: bool = True,
     ) -> None:
         self.model = model
         self.strategy = strategy
+        self.atomic = atomic
 
 
 __all__ = ["PostgresPartitioningConfig"]

--- a/psqlextra/partitioning/shorthands.py
+++ b/psqlextra/partitioning/shorthands.py
@@ -18,6 +18,7 @@ def partition_by_current_time(
     days: Optional[int] = None,
     max_age: Optional[relativedelta] = None,
     name_format: Optional[str] = None,
+    atomic: bool = True,
 ) -> PostgresPartitioningConfig:
     """Short-hand for generating a partitioning config that partitions the
     specified model by time.
@@ -53,6 +54,9 @@ def partition_by_current_time(
         name_format:
             The datetime format which is being passed to datetime.strftime
             to generate the partition name.
+
+        atomic:
+            If set to True, the partitioning operations will be run inside a transaction.
     """
 
     size = PostgresTimePartitionSize(
@@ -61,6 +65,7 @@ def partition_by_current_time(
 
     return PostgresPartitioningConfig(
         model=model,
+        atomic=atomic,
         strategy=PostgresCurrentTimePartitioningStrategy(
             size=size,
             count=count,

--- a/tests/test_partitioning_time.py
+++ b/tests/test_partitioning_time.py
@@ -458,6 +458,7 @@ def test_partitioning_time_delete(kwargs, timepoints):
             assert len(table.partitions) == partition_count
 
 
+@pytest.mark.postgres_version(lt=110000)
 def test_partitioning_time_when_non_atomic():
     model = define_fake_partitioned_model(
         {"timestamp": models.DateTimeField()}, {"key": ["timestamp"]}

--- a/tests/test_partitioning_time.py
+++ b/tests/test_partitioning_time.py
@@ -458,6 +458,28 @@ def test_partitioning_time_delete(kwargs, timepoints):
             assert len(table.partitions) == partition_count
 
 
+def test_partitioning_time_when_non_atomic():
+    model = define_fake_partitioned_model(
+        {"timestamp": models.DateTimeField()}, {"key": ["timestamp"]}
+    )
+
+    schema_editor = connection.schema_editor()
+    schema_editor.create_partitioned_model(model)
+
+    manager = PostgresPartitioningManager(
+        [partition_by_current_time(model=model, count=6, days=7, atomic=False)]
+    )
+
+    with freezegun.freeze_time("2019-1-1"):
+        manager.plan().apply()
+
+    with freezegun.freeze_time("2019-1-15"):
+        manager.plan(skip_create=True).apply()
+
+    table = _get_partitioned_table(model)
+    assert len(table.partitions) == 4
+
+
 @pytest.mark.postgres_version(lt=110000)
 def test_partitioning_time_delete_ignore_manual():
     """Tests whether partitions that were created manually are ignored.

--- a/tests/test_partitioning_time.py
+++ b/tests/test_partitioning_time.py
@@ -467,7 +467,15 @@ def test_partitioning_time_when_non_atomic():
     schema_editor.create_partitioned_model(model)
 
     manager = PostgresPartitioningManager(
-        [partition_by_current_time(model=model, count=6, days=7, atomic=False)]
+        [
+            partition_by_current_time(
+                model=model,
+                count=6,
+                days=7,
+                max_age=relativedelta(weeks=1),
+                atomic=False,
+            )
+        ]
     )
 
     with freezegun.freeze_time("2019-1-1"):


### PR DESCRIPTION
Having non atomic management command can help reduce lock contention.

In this PR a new atomic option has been added to the PostgresPartitioningConfig class. If set to false all changes will be done from outside a transaction. This option is set to True by default so it does not break retrocompatibility.